### PR TITLE
feat: New patch version of History Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN yum install -y procps
 
 WORKDIR /tmp/
 ADD pom.xml /tmp
-RUN curl -o ./spark-3.3.2-bin-without-hadoop.tgz https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-without-hadoop.tgz
-RUN tar -xzf spark-3.3.2-bin-without-hadoop.tgz && \
-    mv spark-3.3.2-bin-without-hadoop /opt/spark && \
-    rm spark-3.3.2-bin-without-hadoop.tgz
+RUN curl -o ./spark-3.3.4-bin-without-hadoop.tgz https://archive.apache.org/dist/spark/spark-3.3.4/spark-3.3.4-bin-without-hadoop.tgz
+RUN tar -xzf spark-3.3.4-bin-without-hadoop.tgz && \
+    mv spark-3.3.4-bin-without-hadoop /opt/spark && \
+    rm spark-3.3.4-bin-without-hadoop.tgz
 RUN mvn dependency:copy-dependencies -DoutputDirectory=/opt/spark/jars/
 RUN rm /opt/spark/jars/jsr305-3.0.0.jar && \
     rm /opt/spark/jars/jersey-*-1.19.4.jar && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/spark-history-server)](https://artifacthub.io/packages/search?repo=spark-history-server)
+[![Docker Image](https://img.shields.io/docker/v/austinorth/spark-history-server/v3.3.4?label=docker&logo=docker)](https://hub.docker.com/repository/docker/austinorth/spark-history-server/tags/v3.3.4)
 
 # Spark History Server
 

--- a/charts/spark-history-server/Chart.yaml
+++ b/charts/spark-history-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spark-history-server
 description: A Helm chart for deploying Spark History Server in Kubernetes
 type: application
-version: 1.1.0
-appVersion: v3.3.2
+version: 1.1.1
+appVersion: v3.3.4

--- a/charts/spark-history-server/README.md
+++ b/charts/spark-history-server/README.md
@@ -1,6 +1,6 @@
 # Spark History Server Helm Chart
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.2](https://img.shields.io/badge/AppVersion-3.3.2-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.4](https://img.shields.io/badge/AppVersion-3.3.4-informational?style=flat-square)
 
 A Helm chart for deploying Spark History Server in Kubernetes to visualize and monitor Spark application metrics.
 


### PR DESCRIPTION
The latest patch version for 3.3 is 3.3.4, so bumping the chart to use that version to increase security. Will release new chart versions for 3.4.4 and 3.5.5 soon as well to have coverage of the latest three minor versions with latest patches.